### PR TITLE
Bump phpunit from 11.5.2 to 11.5.3

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -3,6 +3,6 @@
   <phar name="composer" version="^2.8.4" installed="2.8.4" location="./tools/composer" copy="true"/>
   <phar name="infection" version="^0.29.10" installed="0.29.10" location="./tools/infection" copy="true"/>
   <phar name="phar-io/phive" version="^0.15.3" installed="0.15.3" location="./tools/phive" copy="true"/>
-  <phar name="phpunit" version="^11.5.2" installed="11.5.2" location="./tools/phpunit" copy="true"/>
+  <phar name="phpunit" version="^11.5.3" installed="11.5.3" location="./tools/phpunit" copy="true"/>
   <phar name="psalm" version="^5.26.1" installed="5.26.1" location="./tools/psalm" copy="true"/>
 </phive>


### PR DESCRIPTION
Bumps phpunit from 11.5.2 to 11.5.3.

- Update `tools/phpunit`
- Update `phive.xml`