### PR TITLE
Bump psalm from 5.26.1 to 6.0.0

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -5,5 +5,5 @@
   <phar name="infection" version="^0.29.10" installed="0.29.10" location="./tools/infection" copy="true"/>
   <phar name="phar-io/phive" version="^0.15.3" installed="0.15.3" location="./tools/phive" copy="true"/>
   <phar name="phpunit" version="^11.5.3" installed="11.5.3" location="./tools/phpunit" copy="true"/>
-  <phar name="psalm" version="^5.26.1" installed="5.26.1" location="./tools/psalm" copy="true"/>
+  <phar name="psalm" version="^6.0.0" installed="6.0.0" location="./tools/psalm" copy="true"/>
 </phive>


### PR DESCRIPTION
Bumps psalm from 5.26.1 to 6.0.0.

- Update `tools/psalm`
- Update `phive.xml`