### PR TITLE
Bump `symfony/var-dumper` from `7.2.0` to `7.2.3`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "composer/composer": "^2.8.5",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^11.5.5",
-        "symfony/var-dumper": "^7.2.0",
+        "symfony/var-dumper": "^7.2.3",
         "vimeo/psalm": "^6.0.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "74fb1bef077fc1c7041099bda79ae2fa",
+    "content-hash": "01d76d9491eb9b19b7cd9cf5378d9a9a",
     "packages": [
         {
             "name": "amphp/amp",
@@ -4978,16 +4978,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.2.0",
+            "version": "v7.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "c6a22929407dec8765d6e2b6ff85b800b245879c"
+                "reference": "82b478c69745d8878eb60f9a049a4d584996f73a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/c6a22929407dec8765d6e2b6ff85b800b245879c",
-                "reference": "c6a22929407dec8765d6e2b6ff85b800b245879c",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/82b478c69745d8878eb60f9a049a4d584996f73a",
+                "reference": "82b478c69745d8878eb60f9a049a4d584996f73a",
                 "shasum": ""
             },
             "require": {
@@ -5041,7 +5041,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.2.0"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.2.3"
             },
             "funding": [
                 {
@@ -5057,7 +5057,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-08T15:48:14+00:00"
+            "time": "2025-01-17T11:39:41+00:00"
         },
         {
             "name": "theseer/tokenizer",


### PR DESCRIPTION
Bumps `symfony/var-dumper` from `7.2.0` to `7.2.3`.

- Update `composer.json`
- Update `composer.lock`