### PR TITLE
Bump phpunit from 11.5.6 to 11.5.7

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -4,6 +4,6 @@
   <phar name="composer-normalize" version="^2.45.0" installed="2.45.0" location="./tools/composer-normalize" copy="true"/>
   <phar name="infection" version="^0.29.10" installed="0.29.10" location="./tools/infection" copy="true"/>
   <phar name="phar-io/phive" version="^0.15.3" installed="0.15.3" location="./tools/phive" copy="true"/>
-  <phar name="phpunit" version="^11.5.6" installed="11.5.6" location="./tools/phpunit" copy="true"/>
+  <phar name="phpunit" version="^11.5.7" installed="11.5.7" location="./tools/phpunit" copy="true"/>
   <phar name="psalm" version="^6.4.0" installed="6.4.0" location="./tools/psalm" copy="true"/>
 </phive>


### PR DESCRIPTION
Bumps phpunit from 11.5.6 to 11.5.7.

- Update `tools/phpunit`
- Update `phive.xml`