### PR TITLE
Bump psalm from 6.5.1 to 6.6.0

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -5,5 +5,5 @@
   <phar name="infection" version="^0.29.11" installed="0.29.11" location="./tools/infection" copy="true"/>
   <phar name="phar-io/phive" version="^0.15.3" installed="0.15.3" location="./tools/phive" copy="true"/>
   <phar name="phpunit" version="^12.0.2" installed="12.0.2" location="./tools/phpunit" copy="true"/>
-  <phar name="psalm" version="^6.5.1" installed="6.5.1" location="./tools/psalm" copy="true"/>
+  <phar name="psalm" version="^6.6.0" installed="6.6.0" location="./tools/psalm" copy="true"/>
 </phive>


### PR DESCRIPTION
Bumps psalm from 6.5.1 to 6.6.0.

- Update `tools/psalm`
- Update `phive.xml`