### PR TITLE
Bump psalm from 6.7.1 to 6.8.1

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -5,5 +5,5 @@
   <phar name="infection" version="^0.29.12" installed="0.29.12" location="./tools/infection" copy="true"/>
   <phar name="phar-io/phive" version="^0.15.3" installed="0.15.3" location="./tools/phive" copy="true"/>
   <phar name="phpunit" version="^12.0.3" installed="12.0.3" location="./tools/phpunit" copy="true"/>
-  <phar name="psalm" version="^6.7.1" installed="6.7.1" location="./tools/psalm" copy="true"/>
+  <phar name="psalm" version="^6.8.1" installed="6.8.1" location="./tools/psalm" copy="true"/>
 </phive>


### PR DESCRIPTION
Bumps psalm from 6.7.1 to 6.8.1.

- Update `phive.xml`
- Update `tools/psalm`