### PR TITLE
Bump phpunit from 12.0.6 to 12.0.7

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -4,6 +4,6 @@
   <phar name="composer-normalize" version="^2.45.0" installed="2.45.0" location="./tools/composer-normalize" copy="true"/>
   <phar name="infection" version="^0.29.14" installed="0.29.14" location="./tools/infection" copy="true"/>
   <phar name="phar-io/phive" version="^0.15.3" installed="0.15.3" location="./tools/phive" copy="true"/>
-  <phar name="phpunit" version="^12.0.6" installed="12.0.6" location="./tools/phpunit" copy="true"/>
+  <phar name="phpunit" version="^12.0.7" installed="12.0.7" location="./tools/phpunit" copy="true"/>
   <phar name="psalm" version="^6.8.8" installed="6.8.8" location="./tools/psalm" copy="true"/>
 </phive>


### PR DESCRIPTION
Bumps phpunit from 12.0.6 to 12.0.7.

- Update `phive.xml`
- Update `tools/phpunit`