### PR TITLE
Bump psalm from 6.8.8 to 6.8.9

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -5,5 +5,5 @@
   <phar name="infection" version="^0.29.14" installed="0.29.14" location="./tools/infection" copy="true"/>
   <phar name="phar-io/phive" version="^0.15.3" installed="0.15.3" location="./tools/phive" copy="true"/>
   <phar name="phpunit" version="^12.0.7" installed="12.0.7" location="./tools/phpunit" copy="true"/>
-  <phar name="psalm" version="^6.8.8" installed="6.8.8" location="./tools/psalm" copy="true"/>
+  <phar name="psalm" version="^6.8.9" installed="6.8.9" location="./tools/psalm" copy="true"/>
 </phive>


### PR DESCRIPTION
Bumps psalm from 6.8.8 to 6.8.9.

- Update `phive.xml`
- Update `tools/psalm`