### PR TITLE
Bump `vimeo/psalm` from `6.8.8` to `6.8.9`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^12.0.7",
         "symfony/var-dumper": "^7.2.3",
-        "vimeo/psalm": "^6.8.8"
+        "vimeo/psalm": "^6.8.9"
     },
     "require-dev": {
         "doctrine/inflector": "^2.0.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "01aeedee51e6caa72c25fa6c982a929f",
+    "content-hash": "222574e3f1d33eaf59068f93fba4692f",
     "packages": [
         {
             "name": "amphp/amp",
@@ -6642,16 +6642,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "6.8.8",
+            "version": "6.8.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "1361cd33008feb3ae2b4a93f1860e14e538ec8c2"
+                "reference": "e856423a5dc38d65e56b5792750c557277afe393"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/1361cd33008feb3ae2b4a93f1860e14e538ec8c2",
-                "reference": "1361cd33008feb3ae2b4a93f1860e14e538ec8c2",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/e856423a5dc38d65e56b5792750c557277afe393",
+                "reference": "e856423a5dc38d65e56b5792750c557277afe393",
                 "shasum": ""
             },
             "require": {
@@ -6679,7 +6679,7 @@
                 "spatie/array-to-xml": "^2.17.0 || ^3.0",
                 "symfony/console": "^6.0 || ^7.0",
                 "symfony/filesystem": "~6.3.12 || ~6.4.3 || ^7.0.3",
-                "symfony/polyfill-php84": "*"
+                "symfony/polyfill-php84": "^1.31.0"
             },
             "provide": {
                 "psalm/psalm": "self.version"
@@ -6756,7 +6756,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2025-02-25T17:34:39+00:00"
+            "time": "2025-03-10T13:29:13+00:00"
         },
         {
             "name": "webmozart/assert",


### PR DESCRIPTION
Bumps `vimeo/psalm` from `6.8.8` to `6.8.9`.

- Update `composer.json`
- Update `composer.lock`