### PR TITLE
Bump `vimeo/psalm` from `6.9.1` to `6.9.3`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6642,16 +6642,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "6.9.1",
+            "version": "6.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "81c8a77c0793d450fee40265cfe68891df11d505"
+                "reference": "189990791826d8aa2b72c106ea3b07656534dd61"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/81c8a77c0793d450fee40265cfe68891df11d505",
-                "reference": "81c8a77c0793d450fee40265cfe68891df11d505",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/189990791826d8aa2b72c106ea3b07656534dd61",
+                "reference": "189990791826d8aa2b72c106ea3b07656534dd61",
                 "shasum": ""
             },
             "require": {
@@ -6756,7 +6756,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2025-03-17T09:40:52+00:00"
+            "time": "2025-03-20T10:59:02+00:00"
         },
         {
             "name": "webmozart/assert",


### PR DESCRIPTION
Bumps `vimeo/psalm` from `6.9.1` to `6.9.3`.

- Update `composer.lock`