### PR TITLE
Bump psalm from 6.9.6 to 6.10.0

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -5,5 +5,5 @@
   <phar name="infection" version="^0.29.14" installed="0.29.14" location="./tools/infection" copy="true"/>
   <phar name="phar-io/phive" version="^0.15.3" installed="0.15.3" location="./tools/phive" copy="true"/>
   <phar name="phpunit" version="^12.0.10" installed="12.0.10" location="./tools/phpunit" copy="true"/>
-  <phar name="psalm" version="^6.9.6" installed="6.9.6" location="./tools/psalm" copy="true"/>
+  <phar name="psalm" version="^6.10.0" installed="6.10.0" location="./tools/psalm" copy="true"/>
 </phive>


### PR DESCRIPTION
Bumps psalm from 6.9.6 to 6.10.0.

- Update `./tools/psalm`
- Update `phive.xml`