### PR TITLE
Bump phpunit from 12.0.10 to 12.1.0

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -4,6 +4,6 @@
   <phar name="composer-normalize" version="^2.45.0" installed="2.45.0" location="./tools/composer-normalize" copy="true"/>
   <phar name="infection" version="^0.29.14" installed="0.29.14" location="./tools/infection" copy="true"/>
   <phar name="phar-io/phive" version="^0.15.3" installed="0.15.3" location="./tools/phive" copy="true"/>
-  <phar name="phpunit" version="^12.0.10" installed="12.0.10" location="./tools/phpunit" copy="true"/>
+  <phar name="phpunit" version="^12.1.0" installed="12.1.0" location="./tools/phpunit" copy="true"/>
   <phar name="psalm" version="^6.10.0" installed="6.10.0" location="./tools/psalm" copy="true"/>
 </phive>


### PR DESCRIPTION
Bumps phpunit from 12.0.10 to 12.1.0.

- Update `./tools/phpunit`
- Update `phive.xml`