### PR TITLE
Bump psalm from 6.12.0 to 7.0.0-beta9

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -5,5 +5,5 @@
   <phar name="infection" version="^0.29.14" installed="0.29.14" location="./tools/infection" copy="true"/>
   <phar name="phar-io/phive" version="^0.16.0" installed="0.16.0" location="./tools/phive" copy="true"/>
   <phar name="phpunit" version="^12.1.6" installed="12.1.6" location="./tools/phpunit" copy="true"/>
-  <phar name="psalm" version="^6.12.0" installed="6.12.0" location="./tools/psalm" copy="true"/>
+  <phar name="psalm" version="^7.0.0-beta9" installed="7.0.0-beta9" location="./tools/psalm" copy="true"/>
 </phive>


### PR DESCRIPTION
Bumps psalm from 6.12.0 to 7.0.0-beta9.

- Update `./tools/psalm`
- Update `phive.xml`