### PR TITLE
Bump `phpunit` phar `12.2.1` to `12.2.2`

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -4,6 +4,6 @@
   <phar name="composer-normalize" version="^2.47.0" installed="2.47.0" location="./tools/composer-normalize" copy="true"/>
   <phar name="infection" version="^0.29.14" installed="0.29.14" location="./tools/infection" copy="true"/>
   <phar name="phar-io/phive" version="^0.16.0" installed="0.16.0" location="./tools/phive" copy="true"/>
-  <phar name="phpunit" version="^12.2.1" installed="12.2.1" location="./tools/phpunit" copy="true"/>
+  <phar name="phpunit" version="^12.2.2" installed="12.2.2" location="./tools/phpunit" copy="true"/>
   <phar name="psalm" version="^7.0.0-beta9" installed="7.0.0-beta9" location="./tools/psalm" copy="true"/>
 </phive>


### PR DESCRIPTION
Bumps phpunit phar file from 12.2.1 to 12.2.2.

This pull request changes the following file(s): 

- Update `./tools/phpunit`
- Update `phive.xml`