### PR TITLE
Bump `vimeo/psalm` from `6.12.0` to `6.12.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
         "mockery/mockery": "~1.6.12",
         "nikic/php-parser": "~5.4.0 || ~5.5.0",
         "phpunit/phpunit": "~12.2.6",
-        "vimeo/psalm": "~6.11.0 || ~6.12.0"
+        "vimeo/psalm": "~6.12.1"
     },
     "conflict": {
         "pestphp/pest": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7d79871543b4fa96f8911de7163d2160",
+    "content-hash": "846717ece2148c4491d835b087fa0459",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -6276,16 +6276,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "6.12.0",
+            "version": "6.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "cf420941d061a57050b6c468ef2c778faf40aee2"
+                "reference": "e71404b0465be25cf7f8a631b298c01c5ddd864f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/cf420941d061a57050b6c468ef2c778faf40aee2",
-                "reference": "cf420941d061a57050b6c468ef2c778faf40aee2",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/e71404b0465be25cf7f8a631b298c01c5ddd864f",
+                "reference": "e71404b0465be25cf7f8a631b298c01c5ddd864f",
                 "shasum": ""
             },
             "require": {
@@ -6390,7 +6390,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2025-05-28T12:52:06+00:00"
+            "time": "2025-07-04T09:56:28+00:00"
         },
         {
             "name": "webmozart/assert",


### PR DESCRIPTION
Bumps `vimeo/psalm` from `6.12.0` to `6.12.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`