### PR TITLE
Bump `psalm` phar `7.0.0-beta10` to `7.0.0-beta11`

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -5,5 +5,5 @@
   <phar name="infection" version="^0.30.3" installed="0.30.3" location="./tools/infection" copy="true"/>
   <phar name="phar-io/phive" version="^0.16.0" installed="0.16.0" location="./tools/phive" copy="true"/>
   <phar name="phpunit" version="^12.2.7" installed="12.2.7" location="./tools/phpunit" copy="true"/>
-  <phar name="psalm" version="^7.0.0-beta10" installed="7.0.0-beta10" location="./tools/psalm" copy="true"/>
+  <phar name="psalm" version="^7.0.0-beta11" installed="7.0.0-beta11" location="./tools/psalm" copy="true"/>
 </phive>


### PR DESCRIPTION
Bumps psalm phar file from 7.0.0-beta10 to 7.0.0-beta11.

This pull request changes the following file(s): 

- Update `./tools/psalm`
- Update `phive.xml`