### PR TITLE
Bump `nikic/php-parser` from `v5.5.0` to `v5.6.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
         "ext-xdebug": "*",
         "infection/infection": "~0.30.3",
         "mockery/mockery": "~1.6.12",
-        "nikic/php-parser": "~5.5.0",
+        "nikic/php-parser": "~5.6.0",
         "phpunit/phpunit": "~12.2.7",
         "symfony/var-dumper": "~7.3.1",
         "vimeo/psalm": "~6.13.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "390f1ab0845362500b3e8ea12ef95f96",
+    "content-hash": "1d5ffab313f3a3bbbee7a3324a448544",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -4623,16 +4623,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.5.0",
+            "version": "v5.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "ae59794362fe85e051a58ad36b289443f57be7a9"
+                "reference": "221b0d0fdf1369c71047ad1d18bb5880017bbc56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/ae59794362fe85e051a58ad36b289443f57be7a9",
-                "reference": "ae59794362fe85e051a58ad36b289443f57be7a9",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/221b0d0fdf1369c71047ad1d18bb5880017bbc56",
+                "reference": "221b0d0fdf1369c71047ad1d18bb5880017bbc56",
                 "shasum": ""
             },
             "require": {
@@ -4675,9 +4675,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.5.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.0"
             },
-            "time": "2025-05-31T08:24:38+00:00"
+            "time": "2025-07-27T20:03:57+00:00"
         },
         {
             "name": "ondram/ci-detector",
@@ -7333,7 +7333,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
Bumps `nikic/php-parser` from `v5.5.0` to `v5.6.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`