### PR TITLE
Bump `composer-normalize` phar `2.47.0` to `2.47.0`

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
   <phar name="composer" version="^2.8.10" installed="2.8.10" location="./tools/phar/composer" copy="true"/>
-  <phar name="composer-normalize" version="^2.47.0" installed="2.47.0" location="./tools/phar/composer-normalize" copy="true"/>
+  <phar name="composer-normalize" version="^2.47.0" installed="2.47.0" location="./tools/composer-normalize" copy="true"/>
   <phar name="composer-require-checker" version="^4.16.1" installed="4.16.1" location="./tools/phar/composer-require-checker" copy="true"/>
   <phar name="composer-unused" version="^0.9.4" installed="0.9.4" location="./tools/phar/composer-unused" copy="true"/>
   <phar name="infection" version="^0.31.1" installed="0.31.1" location="./tools/phar/infection" copy="true"/>


### PR DESCRIPTION
Bumps composer-normalize phar file from 2.47.0 to 2.47.0.

This pull request changes the following file(s): 

- Update `phive.xml`