### PR TITLE
Bump `composer-require-checker` phar `4.16.1` to `4.16.1`

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -2,7 +2,7 @@
 <phive xmlns="https://phar.io/phive">
   <phar name="composer" version="^2.8.10" installed="2.8.10" location="./tools/phar/composer" copy="true"/>
   <phar name="composer-normalize" version="^2.47.0" installed="2.47.0" location="./tools/composer-normalize" copy="true"/>
-  <phar name="composer-require-checker" version="^4.16.1" installed="4.16.1" location="./tools/phar/composer-require-checker" copy="true"/>
+  <phar name="composer-require-checker" version="^4.16.1" installed="4.16.1" location="./tools/composer-require-checker" copy="true"/>
   <phar name="composer-unused" version="^0.9.4" installed="0.9.4" location="./tools/phar/composer-unused" copy="true"/>
   <phar name="infection" version="^0.31.1" installed="0.31.1" location="./tools/phar/infection" copy="true"/>
   <phar name="phar-io/phive" version="^0.16.0" installed="0.16.0" location="./tools/phar/phive" copy="true"/>


### PR DESCRIPTION
Bumps composer-require-checker phar file from 4.16.1 to 4.16.1.

This pull request changes the following file(s): 

- Update `phive.xml`