### PR TITLE
Bump `phpbench` phar `1.4.1` to `1.4.1`

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -6,7 +6,7 @@
   <phar name="composer-unused" version="^0.9.4" installed="0.9.4" location="./tools/composer-unused" copy="true"/>
   <phar name="infection" version="^0.31.1" installed="0.31.1" location="./tools/phar/infection" copy="true"/>
   <phar name="phar-io/phive" version="^0.16.0" installed="0.16.0" location="./tools/phive" copy="true"/>
-  <phar name="phpbench" version="^1.4.1" installed="1.4.1" location="./tools/phar/phpbench" copy="true"/>
+  <phar name="phpbench" version="^1.4.1" installed="1.4.1" location="./tools/phpbench" copy="true"/>
   <phar name="phpdocumentor" version="^3.8.1" installed="3.8.1" location="./tools/phar/phpdocumentor" copy="true"/>
   <phar name="phpunit" version="^12.3.1" installed="12.3.1" location="./tools/phar/phpunit" copy="true"/>
   <phar name="psalm" version="^6.13.1" installed="6.13.1" location="./tools/phar/psalm" copy="true"/>


### PR DESCRIPTION
Bumps phpbench phar file from 1.4.1 to 1.4.1.

This pull request changes the following file(s): 

- Update `phive.xml`