### PR TITLE
Bump `phpunit` phar `12.3.1` to `12.3.2`

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -8,6 +8,6 @@
   <phar name="phar-io/phive" version="^0.16.0" installed="0.16.0" location="./tools/phive" copy="true"/>
   <phar name="phpbench" version="^1.4.1" installed="1.4.1" location="./tools/phpbench" copy="true"/>
   <phar name="phpdocumentor" version="^3.8.1" installed="3.8.1" location="./tools/phpdocumentor" copy="true"/>
-  <phar name="phpunit" version="^12.3.1" installed="12.3.1" location="./tools/phar/phpunit" copy="true"/>
+  <phar name="phpunit" version="^12.3.2" installed="12.3.2" location="./tools/phpunit" copy="true"/>
   <phar name="psalm" version="^6.13.1" installed="6.13.1" location="./tools/phar/psalm" copy="true"/>
 </phive>


### PR DESCRIPTION
Bumps phpunit phar file from 12.3.1 to 12.3.2.

This pull request changes the following file(s): 

- Update `phive.xml`