### PR TITLE
Bump `composer` phar `2.8.10` to `2.8.10`

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="composer" version="^2.8.10" installed="2.8.10" location="././tools/phar/composer" copy="true"/>
+  <phar name="composer" version="^2.8.10" installed="2.8.10" location="./tools/phar/composer" copy="true"/>
   <phar name="composer-normalize" version="^2.47.0" installed="2.47.0" location="./tools/phar/composer-normalize" copy="true"/>
   <phar name="composer-require-checker" version="^4.16.1" installed="4.16.1" location="./tools/phar/composer-require-checker" copy="true"/>
   <phar name="composer-unused" version="^0.9.4" installed="0.9.4" location="./tools/phar/composer-unused" copy="true"/>


### PR DESCRIPTION
Bumps composer phar file from 2.8.10 to 2.8.10.