### PR TITLE
Bump `nikic/php-parser` from `v5.6.0` to `v5.6.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
     "require-dev": {
         "ext-xdebug": "*",
         "mockery/mockery": "^1.6.12",
-        "nikic/php-parser": "~5.6.0",
+        "nikic/php-parser": "~5.6.1",
         "phpunit/phpunit": "^12.3.4",
         "symfony/var-dumper": "^7.3.2",
         "vimeo/psalm": "~6.13.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "526aedb8a97cec6f52944d3e75914787",
+    "content-hash": "6ca27fca21173eb3fcd989ace3eaa4c1",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -4192,16 +4192,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.6.0",
+            "version": "v5.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "221b0d0fdf1369c71047ad1d18bb5880017bbc56"
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/221b0d0fdf1369c71047ad1d18bb5880017bbc56",
-                "reference": "221b0d0fdf1369c71047ad1d18bb5880017bbc56",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
                 "shasum": ""
             },
             "require": {
@@ -4220,7 +4220,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
@@ -4244,9 +4244,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
             },
-            "time": "2025-07-27T20:03:57+00:00"
+            "time": "2025-08-13T20:13:15+00:00"
         },
         {
             "name": "phar-io/manifest",


### PR DESCRIPTION
Bumps `nikic/php-parser` from `v5.6.0` to `v5.6.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`