### PR TITLE
Update phpunit phar 12.3.6 to 12.3.7

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -8,6 +8,6 @@
   <phar name="phar-io/phive" version="^0.16.0" installed="0.16.0" location="./tools/phar/phive" copy="true"/>
   <phar name="phpbench" version="^1.4.1" installed="1.4.1" location="./tools/phar/phpbench" copy="true"/>
   <phar name="phpdocumentor" version="^3.8.1" installed="3.8.1" location="./tools/phar/phpdocumentor" copy="true"/>
-  <phar name="phpunit" version="^12.3.6" installed="12.3.6" location="./tools/phar/phpunit" copy="true"/>
+  <phar name="phpunit" version="^12.3.7" installed="12.3.7" location="./tools/phar/phpunit" copy="true"/>
   <phar name="psalm" version="^6.13.1" installed="6.13.1" location="./tools/phar/psalm" copy="true"/>
 </phive>


### PR DESCRIPTION
Updates phpunit phar file from 12.3.6 to 12.3.7.

This pull request changes the following file(s): 

- Update `phive.xml`
- Update `tools/phar/phpunit`