### PR TITLE
Update boundwize/structarmed to version 0.6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
         "ext-zend-opcache": "*",
         "ext-zip": "*",
         "ext-zlib": "*",
-        "boundwize/structarmed": "^0.5.5",
+        "boundwize/structarmed": "^0.6.1",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.1.10",
         "symfony/var-dumper": "^8.0.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "00049e1237756357386cf33484b6734e",
+    "content-hash": "6406f3ab65cec00de385bade93eaae50",
     "packages": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.5.5",
+            "version": "0.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "6da18d0c62553831e402250940d75df04a8c3bc8"
+                "reference": "a13d3ef491e707d40e83c20fd8b1f07e9d96cd8f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/6da18d0c62553831e402250940d75df04a8c3bc8",
-                "reference": "6da18d0c62553831e402250940d75df04a8c3bc8",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/a13d3ef491e707d40e83c20fd8b1f07e9d96cd8f",
+                "reference": "a13d3ef491e707d40e83c20fd8b1f07e9d96cd8f",
                 "shasum": ""
             },
             "require": {
@@ -66,7 +66,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.5.5"
+                "source": "https://github.com/boundwize/structarmed/tree/0.6.1"
             },
             "funding": [
                 {
@@ -74,7 +74,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-15T13:59:43+00:00"
+            "time": "2026-05-15T18:44:44+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.5.5` to `0.6.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`